### PR TITLE
Chore/bump android sdk version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ android {
         applicationId "com.kosukesaigusa.spajam2022final"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
### やったこと
- android/app/build.gradle の compileSdkVersion を 33 に設定
- minSdkVersion を 21 に設定

### 理由
Android エミュレーターでビルドすると以下のエラーが発生したため
```shell
Fix this issue by adding the following to /Users/kentashimizu/development/spajam-2022-final/android/app/build.gradle:
android {
  compileSdkVersion 33
  ...
}

/Users/kentashimizu/development/spajam-2022-final/android/app/src/debug/AndroidManifest.xml Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:cloud_firestore] /Users/kentashimizu/development/spajam-2022-final/build/cloud_firestore/intermediates/merged_manifest/debug/AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 19,
		or use tools:overrideLibrary="io.flutter.plugins.firebase.firestore" to force usage (may lead to runtime failures)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugMainManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:cloud_firestore] /Users/kentashimizu/development/spajam-2022-final/build/cloud_firestore/intermediates/merged_manifest/debug/AndroidManifest.xml as the library might be using APIs not available in 16
  	Suggestion: use a compatible library with a minSdk of at most 16,
  		or increase this project's minSdk version to at least 19,
  		or use tools:overrideLibrary="io.flutter.plugins.firebase.firestore" to force usage (may lead to runtime failures)
```
minSdkVersion は デフォルトで multidex に対応している 21 にしておきました〜！

僕の開発環境では、本PRのソースコードでエミュレーターにビルドできることを確認済みです！